### PR TITLE
Use generic runner with older Ubuntu for piuparts

### DIFF
--- a/.github/workflows/gos-ci.yml
+++ b/.github/workflows/gos-ci.yml
@@ -191,7 +191,7 @@ jobs:
         include:
           - arch: amd64
             subversion: ""
-            runner: self-hosted-generic
+            runner: self-hosted-generic-u2004
           - arch: arm64
             subversion: "v8"
             runner: gos-ci-arm64
@@ -292,4 +292,3 @@ jobs:
     steps:
       - name: Cleanup workspace ${{ github.workspace }}
         uses: greenbone/gos-ci/.github/actions/clean_workspace@main
-


### PR DESCRIPTION
## What

Use generic runner with older Ubuntu for piuparts

## Why

Current runners got newer Ubuntu, but this breaks our piuparts run.
Program lsof is running with 100% CPU for ~15 minutes and runner cancel that job after that.

## References

* https://github.com/actions/runner/issues/2468
* https://github.com/actions/runner-images/discussions/7188