### PR TITLE
Fix: Breaking changes from new docker version

### DIFF
--- a/.github/workflows/gos-ci.yml
+++ b/.github/workflows/gos-ci.yml
@@ -105,7 +105,7 @@ jobs:
         with:
           arch: ${{ matrix.arch }}${{ matrix.subversion }}
           registry: ${{ secrets.GOS_CI_REGISTRY }}
-          debian_release_name: ${{ needs.gather.outputs.debian_release_name }}
+          debian_release_name: trixie
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - name: Upload changes
@@ -226,7 +226,7 @@ jobs:
         with:
           arch: ${{ matrix.arch }}${{ matrix.subversion }}
           registry: ${{ secrets.GOS_CI_REGISTRY }}
-          debian_release_name: ${{ needs.gather.outputs.debian_release_name }}
+          debian_release_name: trixie
         env:
           GITHUB_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
## What

Fix: Breaking changes from new docker version

## Why

DevOps updated their runners to new docker version with breaking changes. Our containers for shredder and older does not have the requirement to work with that new docker version, we are forced to use at least the trixie container.

## References

* https://docs.docker.com/engine/release-notes/29/
* https://jira.greenbone.net/browse/DEVOPS-1845
